### PR TITLE
server: fix "timing attack" in authentication key comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ In this repository is included:
 - **src/**: main source code files.
 - **include/**: include files.
 - **tests/**: automated testbed suite with example configuration files and the script *exec_tests.sh* to run all of them.
-- **tests/api**: automated testbed suite for API interactionand the script *api_tests.sh* to run all of them.
+- **tests/api**: automated testbed suite for API interaction and the script *api_tests.sh* to run all of them.
 
 ## Requirements
 nftlb depends on:


### PR DESCRIPTION
This patch replaces server `auth_key(...)` implementation (relying on `strcmp`, which is vulnerable to "timing attacks") by a safer one. The goal is to prevent server authentication key information leak.

---

Thanks, bye :wave: